### PR TITLE
Friendly error message in case of no release

### DIFF
--- a/src/rebar3_lfe.hrl
+++ b/src/rebar3_lfe.hrl
@@ -1,0 +1,2 @@
+-define(PRV_ERROR(Reason),
+        {error, {?MODULE, Reason}}).


### PR DESCRIPTION
 In case of a user attempting to use run-release without a release
 being generated first, provide the user with a friendly error message
 and instruction.

 - added src/rebar3_lfe.hrl to provide a helpful macro for forming
 provider errors
 - added additional format_error/1 one clause for the missing release
 script case

Closes #48 