### PR TITLE
Ensure generated source dirs are returned

### DIFF
--- a/src/rebar3_lfe_package.erl
+++ b/src/rebar3_lfe_package.erl
@@ -40,7 +40,8 @@
 
 generate_sources(SourceDirs) ->
     AllFiles = [generate_source(Path) || Path <- SourceDirs],
-    rebar_api:debug("All package files: ~p", [AllFiles]).
+    rebar_api:debug("All package files: ~p", [AllFiles]),
+    AllFiles.
 
 generate_source(Path) ->
     Files = files(filename:absname(Path)),


### PR DESCRIPTION
This fixes the issue around lfe not being able to look up lib dirs via `code:lib_dir/1`. 