### PR TITLE
Ensure code paths set for deps on compile

### DIFF
--- a/src/rebar3_lfe_prv_compile.erl
+++ b/src/rebar3_lfe_prv_compile.erl
@@ -50,6 +50,7 @@ format_error(Reason) ->
 
 compile(State) ->
     rebar_api:debug("Compiling LFE apps ...", []),
+    rebar_paths:set_paths(deps, State), 
     Apps = rebar3_lfe_utils:get_apps(State),
     [compile_app(AppInfo) || AppInfo <- Apps],
     {ok, State}.


### PR DESCRIPTION
Fixes issues where `rebar3 lfe compile|repl` would fail because includes could not be found. Should also fix issues where apps were not booting in the REPL (I believe). 