### PR TITLE
Fix call to rebar_paths:set_paths/2

### DIFF
--- a/src/rebar3_lfe_prv_compile.erl
+++ b/src/rebar3_lfe_prv_compile.erl
@@ -50,7 +50,7 @@ format_error(Reason) ->
 
 compile(State) ->
     rebar_api:debug("Compiling LFE apps ...", []),
-    rebar_paths:set_paths(deps, State), 
+    rebar_paths:set_paths([deps], State), 
     Apps = rebar3_lfe_utils:get_apps(State),
     [compile_app(AppInfo) || AppInfo <- Apps],
     {ok, State}.


### PR DESCRIPTION
 - first argument (targets) should be a list, not a bare atom.