### PR TITLE
Reformat template files for `rebar3 new lfe-main`

### DIFF
--- a/priv/templates/LICENSE.tpl
+++ b/priv/templates/LICENSE.tpl
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright {{copyright_year}}, {{author_name}} <{{author_email}}>.
+   Copyright {{copyright_year}} {{author_name}} <{{author_email}}>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/priv/templates/README.md.tpl
+++ b/priv/templates/README.md.tpl
@@ -7,16 +7,16 @@
 
 [![Project Logo][logo]][logo-large]
 
-*{{description}}*
+_{{description}}_
 
-##### Table of Contents
+**Table of Contents**
 
-* [About](#about-)
-* [Build](#build-)
-* [Start the Project REPL](#start-the-repl-)
-* [Tests](#tests-)
-* [Usage](#usage-)
-* [License](#license-)
+- [About](#about-)
+- [Build](#build-)
+- [Start the Project REPL](#repl-)
+- [Tests](#tests-)
+- [Usage](#usage-)
+- [License](#license-)
 
 ## About [&#x219F;](#table-of-contents)
 
@@ -28,13 +28,13 @@ TBD
 $ rebar3 lfe compile
 ```
 
-# Start the Project REPL [&#x219F;](#table-of-contents)
+## REPL [&#x219F;](#table-of-contents)
 
 ```shell
 $ rebar3 lfe repl
 ```
 
-# Tests [&#x219F;](#table-of-contents)
+## Tests [&#x219F;](#table-of-contents)
 
 ```shell
 $ rebar3 as test lfe ltest
@@ -46,11 +46,9 @@ TBD
 
 ## License [&#x219F;](#table-of-contents)
 
-Apache License, Version 2.0
+[Apache License 2.0](LICENSE)
 
-Copyright © {{copyright_year}}, {{author_name}} <{{author_email}}>.
-
-[//]: ---Named-Links---
+Copyright &copy; {{copyright_year}} {{author_name}} &lg;{{author_email}}&gt;
 
 [logo]: https://avatars1.githubusercontent.com/u/3434967?s=250
 [logo-large]: https://avatars1.githubusercontent.com/u/3434967

--- a/priv/templates/cicd.yml
+++ b/priv/templates/cicd.yml
@@ -3,63 +3,51 @@ name: ci/cd
 on:
   workflow_dispatch:
   push:
-    branches: [ main, 'release/*' ]
+    branches:
   pull_request:
-    branches: [ main, 'release/*' ]
+    branches:
   # Build once a month, just to be sure things are still working
   schedule:
-    - cron: "19 3 26 * *"
+    - cron: "0 3 1 * *"
 
 jobs:
-
-  core-builds:
-    name: Erlang ${{ matrix.otp_version }} build
+  main:
+    name: Erlang v${{ matrix.otp_version }}
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        otp_version: ['24.3', '25.3', '26.1']
+        otp_version: ["24.3", "25.3", "26.1"]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ matrix.otp_version }}
-        rebar3-version: '3.22'
-    - name: Compile
-      run: rebar3 compile
-    - name: Xref Checks
-      run: rebar3 xref
-    - name: Dialyzer
-      run: rebar3 dialyzer
-    - name: Proper Tests
-      run: rebar3 as test do compile, proper --regressions
-    - name: Run Unit Tests
-      run: rebar3 as test lfe ltest -tall
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          rebar3-version: "3.22"
 
-  older-builds:
-    name: Old Erlang ${{ matrix.otp_version }} build
+      - run: rebar3 compile
+      - run: rebar3 xref
+      - run: rebar3 dialyzer
+      - run: rebar3 as test do compile, proper --regressions
+      - run: rebar3 as test lfe ltest -tall
+
+  legacy:
+    name: Erlang v${{ matrix.otp_version }}
     runs-on: ubuntu-20.04
-
     strategy:
       matrix:
-        otp_version: ['21.3', '22.3', '23.3']
+        otp_version: ["21.3", "22.3", "23.3"]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ matrix.otp_version }}
-        rebar3-version: '3.15'
-    - name: Compile
-      run: rebar3 compile
-    - name: Xref Checks
-      run: rebar3 xref
-    - name: Dialyzer
-      run: rebar3 dialyzer
-    - name: Compile Tests
-      run: rebar3 as test compile
-    - name: Proper Tests
-      run: rebar3 as test proper --regressions
-    - name: Run Unit Tests
-      run: rebar3 as test lfe ltest -tall
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          rebar3-version: "3.15"
+
+      - run: rebar3 compile
+      - run: rebar3 xref
+      - run: rebar3 dialyzer
+      - run: rebar3 as test compile
+      - run: rebar3 as test proper --regressions
+      - run: rebar3 as test lfe ltest -tall

--- a/priv/templates/gitignore.tpl
+++ b/priv/templates/gitignore.tpl
@@ -31,3 +31,5 @@ logs
 rebar/*
 rebar3.crashdump
 tramp
+.env
+.envrc


### PR DESCRIPTION
Hi!

First time contributing here :) So, I've tried `rebar3 new lfe-main` today to bootstrap a new LFE project, and I promptly noticed minor inconsistencies in the `README.md` Markdown. After looking around for a minute or so, I think I've found the right files to fine-touch it.

I've:

- reformatted the `README.md.tpl` using "best practices" (reads: [Prettier](https://prettier.io/))
- adjusted consistent heading levels for each section (Build, REPL, Tests, etc.)
- Git-ignored common env-specific configuration files (`.env`, and [direnv](https://direnv.net/)'s `.envrc`)
- reformatted the `cicd.yml` template using Prettier, and
  - removed step names (when absent, the command itself will be the "name" – which tells exactly what's being executed)
  - updated  `actions/checkout` to use v4
  - changed `schedule/cron` to run the periodic job at 3 am each 1st day of the month (a more predictable datetime)
  - removed branch definitions for pushes and PRs (it seemed highly based on branches used by [lfe/rebar3](https://github.com/lfe/rebar3))
  - renamed job names to `main` and `legacy` (it seemed more appropriate)

These bite-sized changes might help generate an LFE project that feels more organized, but these are mostly recommendations. Let me know if something doesn't look good and I'll fix it.